### PR TITLE
Fix workspace HTML export bug

### DIFF
--- a/src/scripts/editor-workspace.js
+++ b/src/scripts/editor-workspace.js
@@ -303,7 +303,7 @@ class EditorWorkspace extends HTMLElement {
     this.getDocumentHTML = () => {
       // tools to register
       const doc = this._canvas.cloneNode(true)
-      doc.querySelectorAll(':not(editor-element').forEach(el => el.remove())
+      doc.querySelectorAll(':not(editor-element)').forEach(el => el.remove())
       doc.querySelectorAll('editor-element[class]').forEach(e => {
         e.removeAttribute('class')
       })


### PR DESCRIPTION
## Summary
- fix typo in selector when exporting workspace HTML

## Testing
- `npm run lint` *(fails: `./node_modules/.bin/eslint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843184b0cf883229432598fe8af30be